### PR TITLE
Pull request for: Changes for #57

### DIFF
--- a/scripts/devtools/ckan-tests-nose.sh
+++ b/scripts/devtools/ckan-tests-nose.sh
@@ -10,8 +10,8 @@ fi
 . $(which devtoolconfig.sh)
 
 function run_tests {
-	nosetests -ckan --no-skip --nologcapture   --with-pylons=ckanext-hdx_theme/test.ini.sample ckanext-hdx_theme/ckanext/hdx_theme/tests/ui
-	nosetests -ckan --no-skip --nologcapture --with-pylons=ckanext-metadata_fields/test.ini.sample ckanext-metadata_fields/ckanext/metadata_fields
+	nosetests -ckan --with-xunit --xunit-file=ckanext-metadata_fields/ckanext/metadata_fields/tests/nose_results.xml --nologcapture --with-pylons=ckanext-metadata_fields/test.ini.sample ckanext-metadata_fields/ckanext/metadata_fields
+	nosetests -ckan --with-xunit --xunit-file=ckanext-hdx_theme/ckanext/hdx_theme/tests/nose_results.xml --nologcapture   --with-pylons=ckanext-hdx_theme/test.ini.sample ckanext-hdx_theme/ckanext/hdx_theme
 }
 
 activate;


### PR DESCRIPTION
I've changed a bit the nosetests command to also generate an xml export. So I added:
`--with-xunit --xunit-file=ckanext-hdx_theme/ckanext/hdx_theme/tests/nose_results.xml` and 
`-with-xunit --xunit-file=ckanext-metadata_fields/ckanext/metadata_fields/tests/nose_results.xml`.

This saves the report inside the git project (inside each extension). If you prefer not to pollute the project, please just change the path for _--xunit-file_. I anyway added _nose_results.xml_ to _.gitignore_ on the ckan project.
